### PR TITLE
deprecate

### DIFF
--- a/Casks/quickgpt.rb
+++ b/Casks/quickgpt.rb
@@ -13,7 +13,9 @@ cask "quickgpt" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :ventura"
+  disable! date: "2026-06-08", because: :no_longer_meets_criteria
+
+  depends_on macos: :ventura
 
   app "QuickGPT.app"
 

--- a/Casks/upscayl.rb
+++ b/Casks/upscayl.rb
@@ -13,7 +13,9 @@ cask "upscayl" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
+  disable! date: "2026-06-08", because: :no_longer_meets_criteria
+
+  depends_on macos: :ventura
 
   app "Upscayl.app"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled `quickgpt` cask effective June 8, 2026.
  * Disabled `upscayl` cask effective June 8, 2026.
  * Updated macOS version requirements for affected casks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->